### PR TITLE
Add meaningful alt text to the logo image

### DIFF
--- a/templates/WomensRefugeShieldButton.ss
+++ b/templates/WomensRefugeShieldButton.ss
@@ -2,5 +2,5 @@
 <% require css("andrewandante/womens-refuge-shield: css/button.css") %>
 
 <a href="#" id="womens-refuge-shield-button">
-    <img src="$ResourceURL(andrewandante/womens-refuge-shield: img/logos/custom-logo.png)" alt="Womens refuge shield logo" />
+    <img src="$ResourceURL(andrewandante/womens-refuge-shield: img/logos/custom-logo.png)" alt="Women’s Refuge Shielded Site" />
 </a>


### PR DESCRIPTION
The alt text of an image should ideally not refer to itself, Screen-readers will typically announce the presence of an image before reading the alt text.

See [WAI Tutorials: Superfluous information in the text alternative](https://www.w3.org/WAI/tutorials/images/tips/).